### PR TITLE
Support multi-select import and group into collection

### DIFF
--- a/io_scene_dos2de/__init__.py
+++ b/io_scene_dos2de/__init__.py
@@ -1269,14 +1269,21 @@ class DIVINITYEXPORTER_OT_export_collada(Operator, ExportHelper):
         #mesh = obj.to_mesh(preserve_all_data_layers=True, depsgraph=dg).copy()
         mesh = bpy.data.meshes.new_from_object(object_eval)
 
+        # JATO: Copy over ls_properties manually. mesh.ls_properties is read-only (?) so we do this
+        for ls_props in old_mesh.ls_properties.keys():
+            mesh.ls_properties[ls_props]=old_mesh.ls_properties[ls_props]
+
         # Reset poses
         if self.use_rest_pose:
             for arm in bpy.data.armatures.values():
                 arm.pose_position = armature_poses[arm.name]
 
-        # JATO: Modifiers besides armature may not affect anything but always remove them just in case
-        for modifier in modifiers:
-            obj.modifiers.remove(modifier)
+        '''
+        # JATO: Commented this out because it causes a reference error when exporting without modifiers.
+        This will leave modifiers on the object but as far as I can tell they're not evaluated so it doesn't matter
+        '''
+        #for modifier in modifiers:
+            #obj.modifiers.remove(modifier)
         
         obj.data = mesh
         bpy.data.meshes.remove(old_mesh)

--- a/io_scene_dos2de/__init__.py
+++ b/io_scene_dos2de/__init__.py
@@ -1253,7 +1253,6 @@ class DIVINITYEXPORTER_OT_export_collada(Operator, ExportHelper):
         # JATO: If Apply Modifiers is NOT selected we remove the modifiers before they are evaluated
         if not self.use_mesh_modifiers:
             for modifier in modifiers:
-                print(modifier, " removed")
                 obj.modifiers.remove(modifier)
 
         # JATO: If Apply Shapekeys is NOT selected we remove the shapekeys before they are evaluated

--- a/io_scene_dos2de/export_dae.py
+++ b/io_scene_dos2de/export_dae.py
@@ -181,7 +181,7 @@ class DaeExporter:
         armature_poses = None
         armature_modifier_state = None
         
-        if(self.config["use_exclude_armature_modifier"]):
+        if(self.config["use_apply_pose_to_armature"]):
             armature_modifiers = [i for i in node.modifiers if i.type == "ARMATURE"]
             if len(armature_modifiers) > 0:
                 armature_modifier = armature_modifiers[0]#node.modifiers.get("Armature")


### PR DESCRIPTION
- Supports selecting one or multiple files when importing GR2 files to Blender. This can be useful for viewing/comparing meshes together such as base-bodies and numerous separate garment meshes.

- When imported the armature & meshes are grouped into a Blender collection named after the source file. This can help organize complex scenes and serve as a reminder which assets correspond to which file.

Notes: My programming skills are introductory at best, so please review/test this code 😅