### PR TITLE
Added filtering of exported actions to only the active action on the armature

### DIFF
--- a/io_scene_dos2de/export_dae.py
+++ b/io_scene_dos2de/export_dae.py
@@ -1253,10 +1253,8 @@ class DaeExporter:
                     # animation, animate the skin instead
                     continue
 
-                if (len(node.constraints) > 0 or
-                        node.animation_data is not None):
-                    # If the node has constraints, or animation data, then
-                    # export a sampled animation track
+                # Skip adding animation tracks for armature objects themselves
+                if (node.type != "ARMATURE" and (len(node.constraints) > 0 or node.animation_data is not None)):
                     name = self.validate_id(node.name)
                     if (not (name in xform_cache)):
                         xform_cache[name] = []

--- a/io_scene_dos2de/operators_dae.py
+++ b/io_scene_dos2de/operators_dae.py
@@ -336,9 +336,10 @@ class DIVINITYEXPORTER_OT_export_collada(Operator, ExportHelper):
             elif self.auto_name == "ACTION":
                 armature = None
                 if self.use_active_layers:
-                    obj = next(iter([x for x in context.scene.objects if x.type == "ARMATURE" and x.layers[context.scene.active_layer]]))
-                    if obj is not None:
-                        armature = obj
+                    obj = next(iter([
+                        x for x in context.view_layer.objects 
+                        if x.type == "ARMATURE" and x.visible_get()
+                    ]), None)
                 elif self.use_export_selected:
                     for obj in context.scene.objects:
                         if obj.select_get() and obj.type == "ARMATURE":
@@ -505,7 +506,7 @@ class DIVINITYEXPORTER_OT_export_collada(Operator, ExportHelper):
         description="Export keyframe animation",
         default=False
         )
-    use_anim_action_all = BoolProperty(name="All Actions",
+    use_anim_action_all: BoolProperty(name="All Actions",
         description=("Export all actions for the first armature found in separate DAE files"),
         default=False
         )

--- a/io_scene_dos2de/operators_gltf.py
+++ b/io_scene_dos2de/operators_gltf.py
@@ -24,7 +24,7 @@ class DIVINITYEXPORTER_OT_export_gltf(Operator, ExportHelper):
     filename_ext: StringProperty(
         name="File Extension",
         options={"HIDDEN"},
-        default=".gr2"
+        default=".GR2"
     )
 
     filter_glob: StringProperty(default="*.gr2", options={"HIDDEN"})

--- a/io_scene_dos2de/operators_gltf.py
+++ b/io_scene_dos2de/operators_gltf.py
@@ -49,7 +49,7 @@ class DIVINITYEXPORTER_OT_export_gltf(Operator, ExportHelper):
     use_selection: BoolProperty(
         name="Selected Objects",
         description="Export selected objects only",
-        default=False
+        default=True
     )
 
     use_visible: BoolProperty(

--- a/io_scene_dos2de/operators_gltf.py
+++ b/io_scene_dos2de/operators_gltf.py
@@ -117,6 +117,9 @@ class DIVINITYEXPORTER_OT_export_gltf(Operator, ExportHelper):
             self.divine_settings.x_flip_meshes = scene_props.xflip_on_export
             self.divine_settings.mirror_skeletons = scene_props.xflip_on_export
 
+        if not self.filepath:
+            self.filepath = bpy.path.ensure_ext(bpy.data.filepath.replace(".blend", ""), self.filename_ext)
+        
         context.window_manager.fileselect_add(self)
         self.initialized = True
 

--- a/io_scene_dos2de/operators_gltf.py
+++ b/io_scene_dos2de/operators_gltf.py
@@ -197,7 +197,7 @@ class DIVINITYEXPORTER_OT_import_gltf(Operator, ImportHelper):
     filename_ext: StringProperty(
         name="File Extension",
         options={"HIDDEN"},
-        default=".gr2"
+        default=".GR2"
     )
 
     divine_settings: PointerProperty(

--- a/io_scene_dos2de/operators_gltf.py
+++ b/io_scene_dos2de/operators_gltf.py
@@ -142,6 +142,21 @@ class DIVINITYEXPORTER_OT_export_gltf(Operator, ExportHelper):
 
         context.scene.ls_properties.metadata_version = collada.ColladaMetadataLoader.LSLIB_METADATA_VERSION
 
+        # Temporarily filter out unrelated/unassigned Actions
+        original_action_names = [a.name for a in bpy.data.actions]
+        selected_actions = []
+
+        for obj in context.selected_objects:
+            if obj.type == "ARMATURE":
+                anim_data = obj.animation_data
+                if anim_data and anim_data.action:
+                    selected_actions.append(anim_data.action)
+
+        selected_names = [a.name for a in selected_actions]
+        for act in list(bpy.data.actions):
+            if act.name not in selected_names:
+                bpy.data.actions.remove(act, do_unlink=True)
+        
         result = bpy.ops.export_scene.gltf(filepath=str(gltf_path), export_format='GLB', export_tangents=True,
                                   export_optimize_animation_keep_anim_object=True,
                                   export_bake_animation=True, 
@@ -151,6 +166,11 @@ class DIVINITYEXPORTER_OT_export_gltf(Operator, ExportHelper):
                                   use_renderable=self.use_renderable, use_active_collection=self.use_active_collection,
                                   use_active_scene=self.use_active_scene, export_apply=self.export_apply)
 
+        # Restore all original actions
+        for name in original_action_names:
+            if name not in bpy.data.actions:
+                bpy.data.actions.new(name=name)
+        
         if result != {"FINISHED"}:
             return result
 


### PR DESCRIPTION
Added filtering animations Actions in the .blend to the active one on the armature (otherwise it exports all of the animation actions in the .blend into the same exported GR2 regardless of which armature they were on and if it was selected and meant for export)