### PR TITLE
Set "Export all Armature Actions" to False to filter to the Action on the selected armature

### DIFF
--- a/io_scene_dos2de/operators_gltf.py
+++ b/io_scene_dos2de/operators_gltf.py
@@ -147,6 +147,7 @@ class DIVINITYEXPORTER_OT_export_gltf(Operator, ExportHelper):
 
         result = bpy.ops.export_scene.gltf(filepath=str(gltf_path), export_format='GLB', export_tangents=True,
                                   export_optimize_animation_keep_anim_object=True,
+                                  export_anim_single_armature=False,
                                   export_bake_animation=True, 
                                   export_materials='NONE',
                                   export_morph=False, export_morph_animation=False,

--- a/io_scene_dos2de/operators_gltf.py
+++ b/io_scene_dos2de/operators_gltf.py
@@ -145,21 +145,6 @@ class DIVINITYEXPORTER_OT_export_gltf(Operator, ExportHelper):
 
         context.scene.ls_properties.metadata_version = collada.ColladaMetadataLoader.LSLIB_METADATA_VERSION
 
-        # Temporarily filter out unrelated/unassigned Actions
-        original_action_names = [a.name for a in bpy.data.actions]
-        selected_actions = []
-
-        for obj in context.selected_objects:
-            if obj.type == "ARMATURE":
-                anim_data = obj.animation_data
-                if anim_data and anim_data.action:
-                    selected_actions.append(anim_data.action)
-
-        selected_names = [a.name for a in selected_actions]
-        for act in list(bpy.data.actions):
-            if act.name not in selected_names:
-                bpy.data.actions.remove(act, do_unlink=True)
-        
         result = bpy.ops.export_scene.gltf(filepath=str(gltf_path), export_format='GLB', export_tangents=True,
                                   export_optimize_animation_keep_anim_object=True,
                                   export_bake_animation=True, 
@@ -169,11 +154,6 @@ class DIVINITYEXPORTER_OT_export_gltf(Operator, ExportHelper):
                                   use_renderable=self.use_renderable, use_active_collection=self.use_active_collection,
                                   use_active_scene=self.use_active_scene, export_apply=self.export_apply)
 
-        # Restore all original actions
-        for name in original_action_names:
-            if name not in bpy.data.actions:
-                bpy.data.actions.new(name=name)
-        
         if result != {"FINISHED"}:
             return result
 


### PR DESCRIPTION
Set "Export all Armature Actions" to False so that all of the Actions in the .blend (regardless of armature assignment) are not exported in the same .GR2 (when using GLTF export)