### PR TITLE
glTF import/export settings tweaks

### DIFF
--- a/io_scene_dos2de/operators_gltf.py
+++ b/io_scene_dos2de/operators_gltf.py
@@ -216,7 +216,7 @@ class DIVINITYEXPORTER_OT_import_gltf(Operator, ImportHelper):
                 return {'CANCELLED'}
 
             gltf.glTF2ImportUserExtension.apply_srgb_fixup = self.divine_settings.srgb_colors
-            bpy.ops.import_scene.gltf(filepath=str(gltf_path))
+            bpy.ops.import_scene.gltf(filepath=str(gltf_path), disable_bone_shape=True)
 
             gltf_path.unlink()            
             helpers.report("Import completed successfully.", "INFO")

--- a/io_scene_dos2de/settings.py
+++ b/io_scene_dos2de/settings.py
@@ -119,7 +119,7 @@ class Divine_ImportSettings(PropertyGroup):
     srgb_colors: BoolProperty(
         name="sRGB Colors",
         description="Import mesh color channels as sRGB instead of linear",
-        default=True
+        default=False
     )
 
     def draw(self, context, obj):


### PR DESCRIPTION
Changed settings in the glTF importer:
- Armatures no longer have custom bone shapes assigned to them on import. This provides clearer visual fidelity when editing or manipulating bones in the 3D viewport.
- By default vertex colours now import as linear rather than sRGB. This was changed so the default settings for both import and export would be consistent. Previously the addon would import in sRGB and export in linear by default, this can lead to unintended results for the user as the setting is easily overlooked.